### PR TITLE
Change default status for new Task to 'pending'

### DIFF
--- a/server/controllers/TaskController.js
+++ b/server/controllers/TaskController.js
@@ -21,15 +21,15 @@ export default class TaskController {
     static async create(req, res) {
 
         // Get resource (Task) data passed in the request body
-        const { title, description, scheduleDate, dueDate, status } = req.body;
+        const { title, description, scheduleDate, dueDate } = req.body;
 
         // Setup SQL query
-        let queryTaskInsert = `INSERT INTO tasks (title, description, schedule_date, due_date, status) 
-    VALUES ($1, $2, $3, $4, $5) RETURNING *;`;
+        let queryTaskInsert = `INSERT INTO tasks (title, description, schedule_date, due_date) 
+    VALUES ($1, $2, $3, $4) RETURNING *;`;
 
         try {
             // Execute the SQL query
-            const { rows } = await pool.query(queryTaskInsert, [title, description, scheduleDate, dueDate, status]);
+            const { rows } = await pool.query(queryTaskInsert, [title, description, scheduleDate, dueDate]);
 
             return res.status(201).json({
                 status: 201,

--- a/server/models/createTables.js
+++ b/server/models/createTables.js
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS tasks(
   description VARCHAR(500),
   schedule_date TIMESTAMP,
   due_date TIMESTAMP,
-  status BOOLEAN DEFAULT FALSE,
+  status VARCHAR(30) DEFAULT 'pending',
   created_on TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );`;
 

--- a/server/models/testTables.js
+++ b/server/models/testTables.js
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS tasks(
   description VARCHAR(500) NOT NULL,
   schedule_date TIMESTAMP,
   due_date TIMESTAMP,
-  status BOOLEAN DEFAULT FALSE,
+  status VARCHAR(30) DEFAULT 'pending',
   created_on TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );`;
 


### PR DESCRIPTION
#### What does this PR do?

Set the default status for a newly-created Task to 'pending'.

#### Description of Task to be completed?

As agreed by the team, when a User is creating a new Task from the REST API endpoint, they should not be able to set the status. Instead, the status should be set to 'pending' by default.

#### How should this be manually tested?

- Send a POST request to /api/v1/tasks to create a new Task
- Send a GET request to /api/v1/tasks and check the 'status' field for the created Task